### PR TITLE
fixed-navigation-support-button

### DIFF
--- a/features/layout/sidebar-navigation/sidebar-navigation.tsx
+++ b/features/layout/sidebar-navigation/sidebar-navigation.tsx
@@ -20,6 +20,20 @@ export function SidebarNavigation() {
   const router = useRouter();
   const { isSidebarCollapsed, toggleSidebar } = useContext(NavigationContext);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const handleEmailClick = () => {
+    const email = "support@prolog-app.com";
+    const subject = "Support Request:";
+    //const body = 'How can we help?';
+
+    if (typeof window !== "undefined") {
+      const mailtoLink = `mailto:${email}?subject=${encodeURIComponent(
+        subject,
+      )}`;
+
+      // Open the user's default email client
+      window.location.href = mailtoLink;
+    }
+  };
   return (
     <div
       className={classNames(
@@ -83,7 +97,7 @@ export function SidebarNavigation() {
               text="Support"
               iconSrc="/icons/support.svg"
               isCollapsed={isSidebarCollapsed}
-              onClick={() => alert("Support")}
+              onClick={() => handleEmailClick()}
             />
             <MenuItemButton
               text="Collapse"


### PR DESCRIPTION
fixed-navigation-support-button to show user default email app with auto-filled recipient and subject when clicked
"mailto:" urls are hidden by the browser. Cypress can't see it for an automated test.