### PR TITLE
Fix navigation support button and add cypress test

### DIFF
--- a/cypress/e2e/support-button-for-email.cy.ts
+++ b/cypress/e2e/support-button-for-email.cy.ts
@@ -1,0 +1,27 @@
+describe("Email Button Test", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/dashboard");
+  });
+
+  context("desktop resolution", () => {
+    beforeEach(() => {
+      cy.viewport(1025, 900);
+    });
+
+    // it won't beacause mailto urls are hidden within the browswer. cypress can't see them.
+    it("should update window.location.href with the mailto link and intercept the API request", () => {
+      /*  // Visit the page
+      const email = "support@prolog-app.com";
+      const subject = "Support Request:";
+      // Click the "Support" button
+      cy.contains("button", "Support").trigger("mouseover");
+
+      // Verify the tooltip is visible
+      cy.contains("button", "Support").should(
+        "have.attr",
+        "title",
+        `Send email to: ${email}\nSubject: ${subject}` ,*/
+      cy.contains("button", "Support").click();
+    });
+  });
+});

--- a/cypress/e2e/support-button-for-email.cy.ts
+++ b/cypress/e2e/support-button-for-email.cy.ts
@@ -21,7 +21,9 @@ describe("Email Button Test", () => {
         "have.attr",
         "title",
         `Send email to: ${email}\nSubject: ${subject}` ,*/
-      cy.contains("button", "Support").click();
+      cy.contains("button", "Support").invoke("on", "click", (e) => {
+        e.preventDefault();
+      });
     });
   });
 });


### PR DESCRIPTION
Cypress test is added but, it doesn't help much, as mailto URLs are hidden from Cypress by the browser.
It does open the default email, 
but there is no cypress test function to verify that specifically...only the ability to click the support button.